### PR TITLE
deps(minimist): upgrade minimist package to latest patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "dependencies": {},
   "devDependencies": {
     "tailwindcss": "^3.0.22"
+  },
+  "resolutions": {
+    "minimist": "^1.2.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -368,10 +368,10 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
-minimist@^1.1.1:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@^1.1.1, minimist@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 nanoid@^3.2.0:
   version "3.3.0"


### PR DESCRIPTION
This upgrades `minimist` to the latest patch version to get rid of the [Prototype Pollution vulnerability](https://snyk.io/vuln/npm%3Aminimist)